### PR TITLE
wrap exiftool input directory path in ""

### DIFF
--- a/LapseStudio/Timelapse_API/General/Exiftool.cs
+++ b/LapseStudio/Timelapse_API/General/Exiftool.cs
@@ -25,7 +25,7 @@ namespace Timelapse_API
         /// <returns>a string array with all values</returns>
         public static string[] GetExifMetadata(string directory)
         {
-            SetProcess("-s -ApertureValue -ShutterSpeedValue -ISO -WB_RGGBLevelsAsShot -ColorSpace -ImageSize " + directory, ExifArgument.Metadata);
+            SetProcess("-s -ApertureValue -ShutterSpeedValue -ISO -WB_RGGBLevelsAsShot -ColorSpace -ImageSize \"" + directory + "\"", ExifArgument.Metadata);
             exiftool.Start();
             string CameraData = exiftool.StandardOutput.ReadToEnd();
             exiftool.StandardOutput.Close();


### PR DESCRIPTION
Fixes a problem where calling exiftool didn't work due to spaces in the directory path.